### PR TITLE
Remove border from download box

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -105,9 +105,6 @@ body {
 .download {
     text-align: center;
     padding: 45px;
-    &.top {
-        border: 1px solid rgba(white, 0.1);
-    }
     &.bottom {
         border-top: 1px solid rgba(white, 0.1);
     }


### PR DESCRIPTION
Much nicer without it :)

<img width="1134" alt="screen shot 2015-10-12 at 15 05 08" src="https://cloud.githubusercontent.com/assets/594614/10428570/b54bf1ae-70f2-11e5-95c4-a83c8bf0c1ab.png">
<img width="1121" alt="screen shot 2015-10-12 at 15 05 18" src="https://cloud.githubusercontent.com/assets/594614/10428569/b54a5506-70f2-11e5-8ad6-03b2ba5f0461.png">
